### PR TITLE
Add udev_rules command to install udev rules and check root privileges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ MANIFEST
 build/
 dist/
 *.egg-info/
+.tox/
+.eggs/

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,15 @@
 from __future__ import absolute_import, print_function
 
 from setuptools.command.install import install
-from setuptools import setup
+from setuptools.command.develop import develop
+from setuptools import setup, find_packages
 from distutils.util import execute
+from distutils.cmd import Command
 from subprocess import call
+
+import errno
+import os
+import shutil
 
 
 def udev_reload_rules():
@@ -36,20 +42,55 @@ def udev_trigger():
     call(["udevadm", "trigger", "--subsystem-match=usb", 
           "--attr-match=idVendor=0fcf", "--action=add"])
 
+def install_udev_rules():
+    if check_root():
+        shutil.copy('resources/ant-usb-sticks.rules', '/etc/udev/rules.d')
+        execute(udev_reload_rules, [], "Reloading udev rules")
+        execute(udev_trigger, [], "Triggering udev rules")
+    else:
+        print("You must have root privileges to install udev rules. Run \"sudo python setup.py udev_rules\"")
+
+
+def check_root():
+    return os.geteuid() == 0
+
+
+class InstallUdevRules(Command):
+    description = "install udev rules (requires root privileges)"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        install_udev_rules()
+
 
 class CustomInstall(install):
     def run(self):
         install.run(self)
+        install_udev_rules()
 
-        execute(udev_reload_rules, [], "Reloading udev rules")
-        execute(udev_trigger, [], "Triggering udev rules")
 
+class CustomDevelop(develop):
+    def run(self):
+        develop.run(self)
+        install_udev_rules()
+
+try:
+    with open('README.md') as file:
+        long_description = file.read()
+except IOError:
+    long_description=''
 
 setup(name='openant',
       version='0.2',
 
       description='ANT and ANT-FS Python Library',
-      long_description=open('README.md').read(),
+      long_description=long_description,
 
       author='Gustav Tiger',
       author_email='gustav@tiger.name',
@@ -66,13 +107,11 @@ setup(name='openant',
                    'Topic :: Software Development :: Libraries :: Python Modules'
                    ],
 
-      packages=['ant', 'ant.base', 'ant.easy', 'ant.fs'],
+      packages=find_packages(),
 
       install_requires=['pyusb>=1.0a2'],
-      
-      data_files=[('/etc/udev/rules.d', ['resources/ant-usb-sticks.rules'])],
 
-      cmdclass={'install': CustomInstall},
+      cmdclass={'udev_rules': InstallUdevRules, 'install': CustomInstall, 'develop': CustomDevelop},
 
       test_suite='ant.tests'
       )

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,17 @@ def udev_trigger():
     call(["udevadm", "trigger", "--subsystem-match=usb", 
           "--attr-match=idVendor=0fcf", "--action=add"])
 
-def install_udev_rules():
+def install_udev_rules(raise_exception):
     if check_root():
         shutil.copy('resources/ant-usb-sticks.rules', '/etc/udev/rules.d')
         execute(udev_reload_rules, [], "Reloading udev rules")
         execute(udev_trigger, [], "Triggering udev rules")
     else:
-        print("You must have root privileges to install udev rules. Run \"sudo python setup.py udev_rules\"")
+        msg = "You must have root privileges to install udev rules. Run \"sudo python setup.py udev_rules\""
+        if raise_exception:
+            raise OSError(msg)
+        else:
+            print(msg)
 
 
 def check_root():
@@ -66,25 +70,25 @@ class InstallUdevRules(Command):
         pass
 
     def run(self):
-        install_udev_rules()
+        install_udev_rules(True)
 
 
 class CustomInstall(install):
     def run(self):
         install.run(self)
-        install_udev_rules()
+        install_udev_rules(True)
 
 
 class CustomDevelop(develop):
     def run(self):
         develop.run(self)
-        install_udev_rules()
+        install_udev_rules(False)
 
 try:
     with open('README.md') as file:
         long_description = file.read()
 except IOError:
-    long_description=''
+    long_description = ''
 
 setup(name='openant',
       version='0.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py33,py34,pypy
+[testenv]
+commands=python setup.py test
+usedevelop = True


### PR DESCRIPTION
This installs udev rules when running `python setup.py udev_rules`. It also install those rules when running `python setup.py develop`. 

If user without root access install the module, it runs well and skip udev rules installation while displaying the following message : `You must have root privileges to install udev rules. Run \"sudo python setup.py udev_rules\"`

This PR is required for TravisCI build in CLI project. (https://github.com/Tigge/Garmin-Forerunner-610-Extractor/pull/119)

I've also added a tox configuration file to test in development environment using [tox](https://testrun.org/tox/latest/) on each supported environment.