### PR TITLE
comment de udev section to pass the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(name='openant',
 
       install_requires=['pyusb>=1.0a2'],
 
-      cmdclass={'udev_rules': InstallUdevRules, 'install': CustomInstall, 'develop': CustomDevelop},
+#      cmdclass={'udev_rules': InstallUdevRules, 'install': CustomInstall, 'develop': CustomDevelop},
 
       test_suite='ant.tests'
       )


### PR DESCRIPTION
Here some changes in order to install properly when you use anaconda python distribution.

without this comment in the setup.py (udev), you can't install with sudo python setup.py install. In fact, the installer select system python and the anaconda python.

So the solution is : 

- comment line 120 in setup.py
- install with python setup.py install (without sudo)
- install manually : 

sudo cp resources/ant-usb-sticks.rules /etc/udev/rules.d
sudo udevadm control --reload-rules
sudo udevadm trigger --subsystem-match=usb --attr-match=idVendor=0fcf --action=add
