### PR TITLE
Change from 3 to 10 seconds for timeout

### DIFF
--- a/ant/fs/manager.py
+++ b/ant/fs/manager.py
@@ -365,7 +365,7 @@ class Application:
 
         # New period, search timeout
         self._channel.set_period(4096)
-        self._channel.set_search_timeout(3)
+        self._channel.set_search_timeout(10)
         self._channel.set_rf_freq(self._frequency)
 
     def authentication_serial(self):


### PR DESCRIPTION
I have a vivofit 2. Often, link phase fails due to limited timeout. so I have increased to 10