### PR TITLE
Fix truncated return from UploadDataCommand._parse_args()

### DIFF
--- a/ant/fs/command.py
+++ b/ant/fs/command.py
@@ -302,8 +302,7 @@ class UploadDataCommand(Command):
 
     @classmethod
     def _parse_args(cls, data):
-        return struct.unpack("<BBHI", data[0:8])
-        + (data[8:-8],) + struct.unpack("<6xH", data[-8:])
+        return struct.unpack("<BBHI", data[0:8]) + (data[8:-8],) + struct.unpack("<6xH", data[-8:])
 
 
 class UploadDataResponse(Command):


### PR DESCRIPTION
Picked up by pylint:
```
W:306, 8: Expression "(+(data[8:-8], )) + (struct.unpack('<6xH', data[-8:]))"
is assigned to nothing (expression-not-assigned)
```
Fixes Issue #21