### PR TITLE
Fix pylint warning: singleton-comparsion

### DIFF
--- a/ant/base/ant.py
+++ b/ant/base/ant.py
@@ -115,7 +115,7 @@ class Ant():
             try:
                 message = self.read_message()
 
-                if message == None:
+                if message is None:
                     break
 
                 # TODO: flag and extended for broadcast, acknowledge, and burst


### PR DESCRIPTION
```
************* Module ant.base.ant
Comparison to None should be 'expr is None' (singleton-comparison)
```