### PR TITLE
Add unit test for ant.fs.beacon

### DIFF
--- a/ant/fs/beacon.py
+++ b/ant/fs/beacon.py
@@ -34,6 +34,12 @@ class Beacon:
 
     BEACON_ID = 0x43
 
+    def __init__(self, status_byte_1, status_byte_2, authentication_type, descriptor):
+        self._status_byte_1 = status_byte_1
+        self._status_byte_2 = status_byte_2
+        self._authentication_type = authentication_type
+        self._descriptor = descriptor
+
     def is_data_available(self):
         return bool(self._status_byte_1 & 0x20)  # 0b00100000
 
@@ -57,14 +63,9 @@ class Beacon:
 
     @staticmethod
     def parse(data):
-        values = struct.unpack("<BBBB4x", data)
+        mark, status_byte_1, status_byte_2, authentication_type = struct.unpack("<BBBB4x", data)
 
-        assert values[0] == Beacon.BEACON_ID
+        assert mark == Beacon.BEACON_ID
 
-        beacon = Beacon()
-        beacon._status_byte_1 = values[1]
-        beacon._status_byte_2 = values[2]
-        beacon._authentication_type = values[3]
-        beacon._descriptor = data[4:]
-        return beacon
+        return Beacon(status_byte_1, status_byte_2, authentication_type, data[4:])
 

--- a/ant/fs/beacon.py
+++ b/ant/fs/beacon.py
@@ -59,7 +59,7 @@ class Beacon:
     def parse(data):
         values = struct.unpack("<BBBB4x", data)
 
-        assert values[0] == 0x43
+        assert values[0] == Beacon.BEACON_ID
 
         beacon = Beacon()
         beacon._status_byte_1 = values[1]

--- a/ant/tests/fs/test_beacon.py
+++ b/ant/tests/fs/test_beacon.py
@@ -23,11 +23,22 @@
 from __future__ import absolute_import, print_function
 
 import array
+import unittest
 
 from ant.fs.beacon import Beacon
 
 
-def parse():
-    data = array.array('B', [0x43, 0x04, 0x00, 0x03, 0x41, 0x05, 0x01, 0x00])
-    beacon = Beacon.parse(data)
-    print(beacon)
+class BeaconParseTest(unittest.TestCase):
+    def test_beacon_parse(self):
+        data = array.array('B', [0x43, 0x04, 0x00, 0x03, 0x41, 0x05, 0x01, 0x00])
+
+        beacon = Beacon.parse(data)
+        self.assertIsInstance(beacon, Beacon)
+        self.assertEqual(beacon.is_data_available(), False)
+        self.assertEqual(beacon.is_upload_enabled(), False)
+        self.assertEqual(beacon.is_pairing_enabled(), False)
+        self.assertEqual(beacon.get_channel_period(), 4)
+        self.assertEqual(beacon.get_client_device_state(), Beacon.ClientDeviceState.LINK)
+        self.assertEqual(beacon.get_serial(), 66881)
+        self.assertEqual(beacon.get_descriptor(), (1345, 1))
+


### PR DESCRIPTION
* Avoid magic number `0x43 (Beacon.BEACON_ID)`
* Refactor `ant.fs.beacon` to avoid direct access to protected members of class