### PR TITLE
enable extended messages and background scanning

### DIFF
--- a/ant/base/ant.py
+++ b/ant/base/ant.py
@@ -233,8 +233,6 @@ class Ant():
         pass
 
     def assign_channel(self, channel, channelType, networkNumber, ext_assign):
-        print("ext_assign")
-        print(ext_assign)
         if ext_assign is None:
             message = Message(Message.ID.ASSIGN_CHANNEL, [channel, channelType, networkNumber])
         else:

--- a/ant/base/ant.py
+++ b/ant/base/ant.py
@@ -133,7 +133,8 @@ class Ant():
                     # Response (no channel)
                     elif message._id in [Message.ID.RESPONSE_ANT_VERSION,
                                          Message.ID.RESPONSE_CAPABILITIES,
-                                         Message.ID.RESPONSE_SERIAL_NUMBER]:
+                                         Message.ID.RESPONSE_SERIAL_NUMBER,
+                                         Message.ID.ENABLE_EXT_RX_MESGS]:
                         self._events.put(('response', (None, message._id,
                                                        message._data)))
                     # Response (channel)
@@ -231,8 +232,13 @@ class Ant():
     def unassign_channel(self, channel):
         pass
 
-    def assign_channel(self, channel, channelType, networkNumber):
-        message = Message(Message.ID.ASSIGN_CHANNEL, [channel, channelType, networkNumber])
+    def assign_channel(self, channel, channelType, networkNumber, ext_assign):
+        print("ext_assign")
+        print(ext_assign)
+        if ext_assign is None:
+            message = Message(Message.ID.ASSIGN_CHANNEL, [channel, channelType, networkNumber])
+        else:
+            message = Message(Message.ID.ASSIGN_CHANNEL, [channel, channelType, networkNumber, ext_assign])
         self.write_message(message)
 
     def open_channel(self, channel):
@@ -255,6 +261,10 @@ class Ant():
 
     def set_channel_rf_freq(self, channel, rfFreq):
         message = Message(Message.ID.SET_CHANNEL_RF_FREQ, [channel, rfFreq])
+        self.write_message(message)
+
+    def enable_extended_messages(self, channel, enable):
+        message = Message(Message.ID.ENABLE_EXT_RX_MESGS, [channel, enable])
         self.write_message(message)
 
     def set_network_key(self, network, key):

--- a/ant/easy/channel.py
+++ b/ant/easy/channel.py
@@ -56,8 +56,8 @@ class Channel():
     def wait_for_special(self, event_id):
         return wait_for_special(event_id, self._node._responses, self._node._responses_cond)
 
-    def _assign(self, channelType, networkNumber):
-        self._ant.assign_channel(self.id, channelType, networkNumber)
+    def _assign(self, channelType, networkNumber, ext_assign):
+        self._ant.assign_channel(self.id, channelType, networkNumber, ext_assign)
         return self.wait_for_response(Message.ID.ASSIGN_CHANNEL)
 
     def _unassign(self):
@@ -82,6 +82,10 @@ class Channel():
     def set_rf_freq(self, rfFreq):
         self._ant.set_channel_rf_freq(self.id, rfFreq)
         return self.wait_for_response(Message.ID.SET_CHANNEL_RF_FREQ)
+
+    def enable_extended_messages(self, enable):
+        self._ant.enable_extended_messages(self.id, enable)
+        return self.wait_for_response(Message.ID.ENABLE_EXT_RX_MESGS)
 
     def set_search_waveform(self, waveform):
         self._ant.set_search_waveform(self.id, waveform)
@@ -117,4 +121,3 @@ class Channel():
         except TransferFailedException:
             _logger.warning("failed to send burst transfer %s, retrying", self.id)
             self.send_burst_transfer(data)
-

--- a/ant/easy/node.py
+++ b/ant/easy/node.py
@@ -60,11 +60,11 @@ class Node():
         self._worker_thread = threading.Thread(target=self._worker, name="ant.easy")
         self._worker_thread.start()
 
-    def new_channel(self, ctype, network_number=0x00):
+    def new_channel(self, ctype, network_number=0x00, ext_assign = None):
         size = len(self.channels)
         channel = Channel(size, self, self.ant)
         self.channels[size] = channel
-        channel._assign(ctype, network_number)
+        channel._assign(ctype, network_number, ext_assign)
         return channel
 
     def request_message(self, messageId):
@@ -134,5 +134,4 @@ class Node():
             self._running = False
             self.ant.stop()
             self._worker_thread.join()
-
 

--- a/examples/scan.py
+++ b/examples/scan.py
@@ -1,0 +1,78 @@
+# ANT - Heart Rate Monitor Example
+#
+# Copyright (c) 2012, Gustav Tiger <gustav@tiger.name>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from __future__ import absolute_import, print_function
+
+from ant.easy.node import Node
+from ant.easy.channel import Channel
+from ant.base.message import Message
+
+import logging
+import struct
+import threading
+import sys
+
+NETWORK_KEY= [0xb9, 0xa5, 0x21, 0xfb, 0xbd, 0x72, 0xc3, 0x45]
+
+
+def on_data(data):
+    heartrate = data[7]
+    string = "Heartrate: " + str(heartrate) + " [BPM]"
+
+    sys.stdout.write(string)
+    sys.stdout.flush()
+    sys.stdout.write("\b" * len(string))
+    if len(data)>8:
+        print(data)
+        deviceNumberLSB = data[9]
+        deviceNumberMSB = data[10]
+        deviceNumber = "{}".format(deviceNumberLSB + (deviceNumberMSB<<8))
+        deviceType = "{}".format(data[11])
+        print('New Device Found: %s of type %s' % (deviceNumber,deviceType))
+
+
+def main():
+    logging.basicConfig(filename='example.log',level=logging.DEBUG)
+
+    node = Node()
+    node.set_network_key(0x00, NETWORK_KEY)
+
+    channel = node.new_channel(Channel.Type.BIDIRECTIONAL_RECEIVE,0x00,0x01)
+
+    channel.on_broadcast_data = on_data
+    channel.on_burst_data = on_data
+    channel.on_acknowledge = on_data
+
+    channel.set_id(0, 120, 0)
+    channel.enable_extended_messages(1)
+    channel.set_search_timeout(0xFF)
+    channel.set_period(8070)
+    channel.set_rf_freq(57)
+
+    try:
+        channel.open()
+        node.start()
+    finally:
+        node.stop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
according to chapter "9.5.2.2 Assign Channel"  of the document "ANT_Message_Protocol_and_Usage_Rev_5.1" I added the possibility to set the extended assignment (which is optional). If the extended assignment is set to 0x01, background scanning is enabled (see "5.2.1.4.2 Background Scanning" of the same document).

according to chapter "9.5.2.17 Enable Extended Messages (0x66)" of the same document, the standard data message format can be extended by multiple variable, such as device number, device type, trans type (see chapter "7.1.1 Extended Messages Format").

In the example file "scan.py" I showed the possibilities which come with the new funcitonality. You can now can in an enivronment with multiple ant+ devices for the different device ID (aka device numbers) and connect on a later stage to a specific device number you have found earlier. Thus no need for a wild card and you can be sure to connect to the correct ant+ device