### PR TITLE
Fix USBError: [Errno 32] Pipe error

### DIFF
--- a/ant/base/driver.py
+++ b/ant/base/driver.py
@@ -213,13 +213,7 @@ try:
 
             # get an endpoint instance
             cfg = dev.get_active_configuration()
-            interface_number = cfg[(0, 0)].bInterfaceNumber
-            alternate_setting = usb.control.get_interface(dev, interface_number)
-            intf = usb.util.find_descriptor(
-                cfg,
-                bInterfaceNumber=interface_number,
-                bAlternateSetting=alternate_setting,
-            )
+            intf = cfg[(0, 0)]
 
             self._out = usb.util.find_descriptor(
                 intf,


### PR DESCRIPTION
Fixes #51

Implements the patch inspired by @theller.

There's not need to set `intf` take it's attributes and then make an
identical `intf`:

```
intf = cfg[(0, 0)]
interface_number = intf.bInterfaceNumber
alternate_setting = intf.bAlternateSetting

intf = usb.util.find_descriptor(
    cfg,
    bInterfaceNumber=interface_number,
    bAlternateSetting=alternate_setting,
)
```