### PR TITLE
Fix problem with pyusb 1.0.2

### DIFF
--- a/openant/base/ant.py
+++ b/openant/base/ant.py
@@ -234,7 +234,7 @@ class Ant:
                 self._last_data = message._data
 
             except USBError as e:
-                if not isinstance(e, usb.core.USBTimeoutError):
+                if usb.version_info < (1, 1, 0) or not isinstance(e, usb.core.USBTimeoutError):
                     _logger.warning("%s, %r", type(e), e.args)
                 else:
                     _logger.debug(f"Timeout waiting for message: {e.args}")


### PR DESCRIPTION
USBTimeoutError was introduced in pyusb 1.1.0, so we need to check pyusb version before using it.
