### PR TITLE
Fix antfs crash

### DIFF
--- a/openant/fs/manager.py
+++ b/openant/fs/manager.py
@@ -194,7 +194,7 @@ class Application:
         return c
 
     def _send_command(self, c):
-        data = c.get()
+        data = c.get().tolist()
         if len(data) == 8:
             self._channel.send_acknowledged_data(data)
         else:


### PR DESCRIPTION
aed862c9 changed the expected data type of argument data for Ant.send_acknowledged_data and Ant.send_burst_transfer_packet, but antfs code was not updated resulting in a crash when an array can't be appended to a list:

TypeError: can only concatenate list (not "array.array") to list

----

I haven't thought much about the fix. There may be a more correct way to handle this.