### PR TITLE
specify packages.find include #114

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -32,9 +32,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
       run: |
         cd docs
         make html
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: sphinx-out
         path: ./docs/_build/
@@ -52,9 +52,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Build wheel and sdist
@@ -69,9 +69,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install pypa/build

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test if requires format with Black
         uses: psf/black@stable
         with:

--- a/openant/__init__.py
+++ b/openant/__init__.py
@@ -31,7 +31,7 @@ from . import fs
 from . import devices
 
 __all__ = ["base", "easy", "fs", "devices"]
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 
 # subparser importer taken from cantools module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,9 @@ docs = ["sphinx>=5.2.3", "furo>=2021.3.20b30", "sphinx_mdinclude"]
 [project.scripts]
 openant = "openant.__init__:_main"
 
-[tool.setuptools]
-packages = ["openant"]
+# specify to avoid symbolic link ant
+[tool.setuptools.packages.find]
+include = ["openant*"]
 
 [tool.setuptools.dynamic]
 readme = { file = "README.md" }


### PR DESCRIPTION
’openant’ is the only package and we should be specific to avoid import of ‘ant’ symbolic link, which might create namespace conflicts.

I notice this was indeed issuing warnings previously when using `python -m build`: 

`…writing manifest file 'openant.egg-info/SOURCES.txt'                                                                               
/private/var/folders/tb/sw7c7pfd2wg295y5l3wllg500000gn/T/build-env-s4qz7vkf/lib/python3.13/site-packages/setuptools/command/build_p
y.py:212: _Warning: Package 'openant.base' is absent from the `packages` configuration. …`

Should now be fixed and close #114.