### PR TITLE
Filter influx import types, add calculated speed and distance to BikeSpeedData

### DIFF
--- a/openant/devices/common.py
+++ b/openant/devices/common.py
@@ -92,9 +92,13 @@ class DeviceData:
         """
         fields = {name: getattr(self, name) for name in self.__dataclass_fields__}
 
-        for f in fields:
-            if isinstance(fields[f], Enum):
-                fields[f] = fields[f].value
+        # convert enums to values and filter out non numeric fields
+        filtered = {}
+        for k, v in fields.items():
+            if isinstance(v, Enum):
+                filtered.update({k: v.value})
+            elif isinstance(v, (int, float)):
+                filtered.update({k: v})
 
         return {
             "measurement": type(self).__name__,
@@ -105,7 +109,7 @@ class DeviceData:
                 .timestamp()
                 * 1e9
             ),
-            "fields": fields,
+            "fields": filtered,
         }
 
 


### PR DESCRIPTION
InfluxDB doesn't support list etc. so filter fields to int or float.

The BikeSpeedData isn't very useful as import so add calculated_speed and calculated_distance. These are cached values that when `calculate_speed` and `calculate_distance` are called, will be saved.

`update_speed_data` will do this if a `wheel_circumference_m` is passed. The ANT+ devices which use this dataclass have a optional `wheel_circumference_m` added to do this - one must initiate with this keyword arg to do this.

Closes #117 