### PR TITLE
Publish ANT+ data to MQTT server

### DIFF
--- a/openant/base/datatarget.py
+++ b/openant/base/datatarget.py
@@ -1,0 +1,166 @@
+import argparse
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from ..easy.node import Node
+
+from ..devices import device_profiles, ANTPLUS_NETWORK_KEY
+from ..devices.utilities import auto_create_device, read_json
+from ..devices.common import DeviceData, AntPlusDevice
+from ..devices.fitness_equipment import FitnessEquipment, Workout
+
+class DataTarget(ABC):
+    @abstractmethod
+    def __init__(self, args: argparse.Namespace):
+        pass
+
+    @abstractmethod
+    def write_data(self, device: AntPlusDevice, page_name: str, data: DeviceData):
+        print(f"Device {device} broadcast {page_name} data: {data}")
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    def run(self,
+        node: Node,
+        devices: List[AntPlusDevice],
+        workouts: Optional[List[Workout]] = None):
+        print(f"Starting device data importer for {devices}")
+
+        def on_found(device):
+            print(f"Device {device} found and receiving")
+
+            if type(device) == FitnessEquipment:
+                if workouts is not None:
+                    device.start_workouts(workouts)
+
+        for dev in devices:
+            dev.on_found = lambda dev=dev: on_found(dev)
+            dev.on_device_data = lambda page, page_name, data, dev=dev: self.write_data(
+                dev, page_name, data
+            )
+
+        try:
+            print(f"Starting {devices}, press Ctrl-C to finish")
+            node.start()
+        except KeyboardInterrupt:
+            print(f"Closing ANT+ devices...")
+        finally:
+            for dev in devices:
+                dev.close_channel()
+
+            node.stop()
+            self.close()
+
+    @classmethod
+    def add_general_arguments(cls, subparser):
+        subparser.add_argument(
+            "device",
+            choices=list(device_profiles.keys()).append("config"),
+            help=f"Device {list(device_profiles.keys())} to use or 'config' for --config flag file",
+        )
+        subparser.add_argument(
+            "--config",
+            type=str,
+            help=".json config file for use with 'config' type",
+        )
+        subparser.add_argument(
+            "-I",
+            "--id",
+            type=int,
+            default=0,
+            help="Device ID, default zero will attach to first found",
+        )
+        subparser.add_argument(
+            "-T",
+            "--transtype",
+            type=int,
+            default=0,
+            help="Transmission type, default zero will attach to first found",
+        )
+        subparser.add_argument(
+            "-V", "--verbose", action="store_true", help="verbose output"
+        )
+
+    @classmethod
+    def entry(cls, args):
+        target = cls(args)
+
+        node = Node()
+        node.set_network_key(0x00, ANTPLUS_NETWORK_KEY)
+
+        devices = []
+        workouts = None
+
+        # load from config file if config
+        if args.device == "config":
+            if args.config:
+                config = read_json(args.config)
+
+                if config:
+                    # bit dirty but initialises classes based on snake_case string provided - TODO change when imported from module
+                    for dev in config["devices"]:
+                        try:
+                            class_name = dev["device"]
+                            device_id = dev["id"]
+                            trans_type = dev["transmission_type"]
+                            devices.append(
+                                auto_create_device(
+                                    node,
+                                    device_id=device_id,
+                                    device_type=class_name,
+                                    trans_type=trans_type,
+                                )
+                            )
+                        except Exception as e:
+                            raise ValueError(
+                                f"Failed to create device {dev} from {args.config} - is it a valid AntPlusDevice?"
+                            )
+
+                    if "workouts" in config:
+                        try:
+                            workouts = [
+                                Workout.from_arrays(
+                                    x["powers"],
+                                    x["periods"],
+                                    cycles=x["cycles"],
+                                    loop=x["loop"],
+                                )
+                                if x["type"] == "arrays"
+                                else Workout.from_ramp(
+                                    start=x["start"],
+                                    stop=x["stop"],
+                                    step=x["step"],
+                                    period=x["period"],
+                                    peak=(x["peak"] if "peak" in x else None),
+                                    cycles=x["cycles"],
+                                    loop=x["loop"],
+                                )
+                                for x in config["workouts"]
+                            ]
+                        except Exception as e:
+                            print(f"Failed to parse workouts in {args.config}: {e}")
+
+                else:
+                    raise ValueError("Invalid or missing config file")
+            else:
+                raise ValueError(
+                    "--config arg with path to .json device configuation must be supplied!"
+                )
+        # else create DeviceType class
+        else:
+            devices.append(
+                auto_create_device(
+                    node,
+                    device_id=args.id,
+                    device_type=args.device,
+                    trans_type=args.transtype,
+                )
+            )
+
+        target.run(
+            node=node,
+            devices=devices,
+            workouts=workouts
+        )

--- a/openant/devices/common.py
+++ b/openant/devices/common.py
@@ -104,7 +104,7 @@ class DeviceData:
             "measurement": type(self).__name__,
             "tags": tags,
             "time": int(
-                datetime.datetime.now(datetime.UTC)
+                datetime.datetime.now(datetime.timezone.utc)
                 .timestamp()
                 * 1e9
             ),

--- a/openant/subparsers/influx.py
+++ b/openant/subparsers/influx.py
@@ -1,226 +1,82 @@
+import argparse
 import os
 import uuid
-from typing import List, Optional
 
-from ..easy.node import Node
+from ..base.datatarget import DataTarget
 
-from ..devices import device_profiles, ANTPLUS_NETWORK_KEY
-from ..devices.utilities import auto_create_device, read_json
 from ..devices.common import DeviceData, AntPlusDevice
-from ..devices.fitness_equipment import FitnessEquipment, Workout
 
 import influxdb_client as idb
 from influxdb_client.client.write_api import SYNCHRONOUS
 
 
-def write_device_data_influx(
-    data: DeviceData,
-    client: idb.InfluxDBClient,
-    bucket: str,
-    wuuid: str,
-    device_name: str,
-    verbose=True,
-):
-    host = os.uname().nodename
+class InfluxTarget(DataTarget):
 
-    if not data:
-        raise ValueError("Device has no data")
+    def __init__(self, args: argparse.Namespace):
+        self.bucket = args.bucket
+        self.session_uuid: str = str(uuid.uuid4())
+        self.client: idb.InfluxDBClient = self.create_connection(args)
+        self.verbose: bool = args.verbose
 
-    try:
-        influx_tags = {
-            "device": device_name,
-            "uuid": wuuid,
-            "host": host,
-        }
+    @staticmethod
+    def create_connection(args: argparse.Namespace) -> idb.InfluxDBClient:
+        # create influx connection
+        client = idb.InfluxDBClient(url=args.url, token=args.token, org=args.org)
 
-        json = data.to_influx_json(tags=influx_tags)
+        if args.verbose:
+            print(f"Created InfluxDB {client}")
 
-        if verbose:
-            print(f"Writing: {json}")
+        # ping client now before stream
+        client.ping()
+        return client
 
-        point = point = idb.Point.from_dict(json)
+    def write_data(self, device: AntPlusDevice, page_name: str, data: DeviceData):
+        super().write_data(device, page_name, data)
+        InfluxTarget._write_device_data_influx(
+            data,
+            self.client,
+            bucket=self.bucket,
+            wuuid=self.session_uuid,
+            device_name=str(device),
+            verbose=self.verbose,
+        )
 
-        with client.write_api(write_options=SYNCHRONOUS) as c:
-            c.write(bucket=bucket, record=point)
+    def close(self):
+        self.client.close()
 
-    except Exception as e:
-        print(f"Exception during influx write: {e}")
+    @staticmethod
+    def _write_device_data_influx(
+        data: DeviceData,
+        client: idb.InfluxDBClient,
+        bucket: str,
+        wuuid: str,
+        device_name: str,
+        verbose=True,
+    ):
+        host = os.uname().nodename
 
+        if not data:
+            raise ValueError("Device has no data")
 
-def write_all_device_data_influx(
-    device: AntPlusDevice,
-    client: idb.InfluxDBClient,
-    bucket: str,
-    wuuid: str,
-    verbose=True,
-):
-    host = os.uname().nodename
+        try:
+            influx_tags = {
+                "device": device_name,
+                "uuid": wuuid,
+                "host": host,
+            }
 
-    try:
-        influx_tags = {
-            "device": str(device),
-            "serial_no": device.data["common"].serial_no,
-            "uuid": wuuid,
-            "host": host,
-        }
+            json = data.to_influx_json(tags=influx_tags)
 
-        # drop common since it's just const meta
-        data = device.data.copy()
-        data.pop("common")
+            if verbose:
+                print(f"Writing: {json}")
 
-        json = [v.to_influx_json(tags=influx_tags) for v in data.values()]
+            point = point = idb.Point.from_dict(json)
 
-        if verbose:
-            print(f"Writing: {json}")
-
-        with client.write_api(write_options=SYNCHRONOUS) as c:
-            for j in json:
-                point = point = idb.Point.from_dict(j)
+            with client.write_api(write_options=SYNCHRONOUS) as c:
                 c.write(bucket=bucket, record=point)
 
-    except Exception as e:
-        print(f"Exception during influx write: {e}")
-
-
-def device_data_influx_importer(
-    node: Node,
-    client: idb.InfluxDBClient,
-    bucket: str,
-    devices: List[AntPlusDevice],
-    session_uuid: str = str(uuid.uuid4()),
-    verbose: bool = False,
-    workouts: Optional[List[Workout]] = None,
-):
-    print(f"Starting device data importer UUID {session_uuid} for {devices}")
-
-    # method with args saved to pass to device page update callback - could pass args list with callback instead if this gets messsy...
-    def write_device_data(device, page_name, data):
-        print(f"Device {device} broadcast {page_name} data: {data}")
-        write_device_data_influx(
-            data,
-            client,
-            bucket=bucket,
-            wuuid=session_uuid,
-            device_name=str(device),
-            verbose=verbose,
-        )
-
-    def on_found(device):
-        print(f"Device {device} found and receiving")
-
-        if type(device) == FitnessEquipment:
-            if workouts is not None:
-                device.start_workouts(workouts)
-
-    for dev in devices:
-        dev.on_found = lambda dev=dev: on_found(dev)
-        dev.on_device_data = lambda page, page_name, data, dev=dev: write_device_data(
-            dev, page_name, data
-        )
-
-    try:
-        print(f"Starting {devices}, press Ctrl-C to finish")
-        node.start()
-    except KeyboardInterrupt:
-        print(f"Closing ANT+ devices...")
-    finally:
-        for dev in devices:
-            dev.close_channel()
-
-        node.stop()
-        client.close()
-
-
-def _run(args):
-    # create influx connection
-    client = idb.InfluxDBClient(url=args.url, token=args.token, org=args.org)
-
-    if args.verbose:
-        print(f"Created InfluxDB {client}")
-
-    # ping client now before stream
-    client.ping()
-
-    node = Node()
-    node.set_network_key(0x00, ANTPLUS_NETWORK_KEY)
-
-    devices = []
-    workouts = None
-
-    # load from config file if config
-    if args.device == "config":
-        if args.config:
-            config = read_json(args.config)
-
-            if config:
-                # bit dirty but initialises classes based on snake_case string provided - TODO change when imported from module
-                for dev in config["devices"]:
-                    try:
-                        class_name = dev["device"]
-                        device_id = dev["id"]
-                        trans_type = dev["transmission_type"]
-                        devices.append(
-                            auto_create_device(
-                                node,
-                                device_id=device_id,
-                                device_type=class_name,
-                                trans_type=trans_type,
-                            )
-                        )
-                    except Exception as e:
-                        raise ValueError(
-                            f"Failed to create device {dev} from {args.config} - is it a valid AntPlusDevice?"
-                        )
-
-                if "workouts" in config:
-                    try:
-                        workouts = [
-                            Workout.from_arrays(
-                                x["powers"],
-                                x["periods"],
-                                cycles=x["cycles"],
-                                loop=x["loop"],
-                            )
-                            if x["type"] == "arrays"
-                            else Workout.from_ramp(
-                                start=x["start"],
-                                stop=x["stop"],
-                                step=x["step"],
-                                period=x["period"],
-                                peak=(x["peak"] if "peak" in x else None),
-                                cycles=x["cycles"],
-                                loop=x["loop"],
-                            )
-                            for x in config["workouts"]
-                        ]
-                    except Exception as e:
-                        print(f"Failed to parse workouts in {args.config}: {e}")
-
-            else:
-                raise ValueError("Invalid or missing config file")
-        else:
-            raise ValueError(
-                "--config arg with path to .json device configuation must be supplied!"
-            )
-    # else create DeviceType class
-    else:
-        devices.append(
-            auto_create_device(
-                node,
-                device_id=args.id,
-                device_type=args.device,
-                trans_type=args.transtype,
-            )
-        )
-
-    device_data_influx_importer(
-        node=node,
-        client=client,
-        bucket=args.bucket,
-        devices=devices,
-        verbose=args.verbose,
-        workouts=workouts,
-    )
+        except Exception as e:
+            print(f"Exception during influx write: {e}")
 
 
 def add_subparser(subparsers, name="influx"):
@@ -228,54 +84,29 @@ def add_subparser(subparsers, name="influx"):
         name,
         description=("Capture DeviceData from an ANT+ device and import to InfluxDB"),
     )
-    antinflux.add_argument(
-        "device",
-        choices=list(device_profiles.keys()).append("config"),
-        help=f"Device {list(device_profiles.keys())} to use or 'config' for --config flag file",
-    )
-    antinflux.add_argument(
-        "--config",
-        type=str,
-        help=".json config file for use with 'config' type",
-    )
-    antinflux.add_argument(
+    DataTarget.add_general_arguments(antinflux)
+    influx_args = antinflux.add_argument_group(f'{name} options')
+    influx_args.add_argument(
         "--url",
         default="http://localhost:8086",
         type=str,
         help="URL for InfluxDB server",
     )
-    antinflux.add_argument(
+    influx_args.add_argument(
         "--token",
         type=str,
         help="port of InfluxDB server",
     )
-    antinflux.add_argument(
+    influx_args.add_argument(
         "--org",
         default="my-org",
         type=str,
         help="organisation to use on InfluxDB server",
     )
-    antinflux.add_argument(
+    influx_args.add_argument(
         "--bucket",
         type=str,
         default="my-bucket",
         help="influxDB bucket to write to",
     )
-    antinflux.add_argument(
-        "-I",
-        "--id",
-        type=int,
-        default=0,
-        help="Device ID, default zero will attach to first found",
-    )
-    antinflux.add_argument(
-        "-T",
-        "--transtype",
-        type=int,
-        default=0,
-        help="Transmission type, default zero will attach to first found",
-    )
-    antinflux.add_argument(
-        "-V", "--verbose", action="store_true", help="verbose output"
-    )
-    antinflux.set_defaults(func=_run)
+    antinflux.set_defaults(func=InfluxTarget.entry)

--- a/openant/subparsers/influx.py
+++ b/openant/subparsers/influx.py
@@ -2,12 +2,11 @@ import argparse
 import os
 import uuid
 
-from ..base.datatarget import DataTarget
-
-from ..devices.common import DeviceData, AntPlusDevice
-
 import influxdb_client as idb
 from influxdb_client.client.write_api import SYNCHRONOUS
+
+from ..base.datatarget import DataTarget
+from ..devices.common import DeviceData, AntPlusDevice
 
 
 class InfluxTarget(DataTarget):
@@ -85,7 +84,7 @@ def add_subparser(subparsers, name="influx"):
         description=("Capture DeviceData from an ANT+ device and import to InfluxDB"),
     )
     DataTarget.add_general_arguments(antinflux)
-    influx_args = antinflux.add_argument_group(f'{name} options')
+    influx_args = antinflux.add_argument_group(f"{name} options")
     influx_args.add_argument(
         "--url",
         default="http://localhost:8086",

--- a/openant/subparsers/mqtt.py
+++ b/openant/subparsers/mqtt.py
@@ -1,0 +1,145 @@
+import argparse
+import json
+import time
+import traceback
+import uuid
+
+import paho.mqtt.client as mqtt
+
+from ..base.datatarget import DataTarget
+from ..devices.common import AntPlusDevice, DeviceData
+
+
+class MqttTarget(DataTarget):
+
+    def __init__(self, args: argparse.Namespace):
+        super().__init__(args)
+        self.args = args
+        self.client_id: str = "openant-mqtt_" + str(uuid.uuid4())
+        self.mqttc: mqtt.Client = self._create_client(args)
+        self.device_topics: dict[tuple[int, int], str] = dict(
+            self.args.device_topics or []
+        )
+
+    def write_data(
+        self, device: AntPlusDevice, page_name: str, data: DeviceData
+    ) -> None:
+        super().write_data(device, page_name, data)
+        device_topic = self._determine_topic(device)
+        x = data.to_influx_json({})
+        payload = {"_type": x["measurement"]}
+        payload.update(x["fields"])
+
+        self.mqttc.loop_start()
+        if self.args.topic_per_field:
+            for field, value in payload.items():
+                field_topic = device_topic + "/" + field
+                self.mqttc.publish(field_topic, value)
+        else:
+            payload = json.dumps(payload)
+            self.mqttc.publish(device_topic, payload)
+        self.mqttc.loop_stop()
+
+    def close(self) -> None:
+        super().close()
+        self.mqttc.disconnect()
+
+    def _create_client(self, args: argparse.Namespace) -> mqtt.Client:
+        mqttc = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION2,
+            client_id=self.client_id,
+            clean_session=False,
+            userdata=self,
+        )
+        mqttc.username_pw_set(args.user, args.password)
+        mqttc.connect(args.host, args.port)
+        mqttc.on_disconnect = self.on_disconnect
+        return mqttc
+
+    def _determine_topic(self, device: AntPlusDevice) -> str:
+        topic = f"openant/{type(device).__name__}/{device.device_id}"
+        key = device.device_type, device.device_id
+        return self.device_topics.get(key, topic)
+
+    @staticmethod
+    def on_disconnect(
+        client: mqtt.Client, userdata, disconnect_flags, reason_code, properties
+    ):
+        target: DataTarget = userdata
+        if target.shutting_down:
+            print("Shutdown in progress, will not reconnect")
+            return
+        retries = 10
+        delay = 5
+        backoff = 1.5
+        while retries > 0:
+            try:
+                print(f"Reconnecting in {delay}")
+                time.sleep(delay)
+                client.reconnect()
+                print("Successful reconnect")
+                return
+            except Exception:
+                print("Reconnect failed")
+                traceback.print_exc()
+            retries -= 1
+            delay *= backoff
+
+
+def add_subparser(subparsers, name="mqtt"):
+    antmqtt = subparsers.add_parser(
+        name,
+        description=(
+            "Capture DeviceData from an ANT+ device and publish to MQTT server."
+            "Data will be published under openant/<DeviceType>/<DeviceId> by default."
+            "If you wish to control the topic in detail, use --device-topic."
+        ),
+    )
+    DataTarget.add_general_arguments(antmqtt)
+    mqtt_args = antmqtt.add_argument_group(f"{name} options")
+    mqtt_args.add_argument(
+        "--host",
+        default="localhost",
+        type=str,
+        help="Host for MQTT server",
+    )
+    mqtt_args.add_argument(
+        "--port",
+        default=1883,
+        type=int,
+        help="Port for MQTT server",
+    )
+    mqtt_args.add_argument(
+        "--user",
+        type=str,
+        help="User for MQTT server",
+    )
+    mqtt_args.add_argument(
+        "--password",
+        type=str,
+        help="Password for MQTT server",
+    )
+    mqtt_args.add_argument(
+        "--topic-per-field",
+        action="store_true",
+        help="Publish fields to individual topics under the device node, rather than all fields as JSON)",
+    )
+
+    def device_topic(s):
+        try:
+            temp = s.split(":", 3)
+            return tuple(map(int, temp[0:2])), temp[2]
+        except Exception as exc:
+            raise argparse.ArgumentTypeError(
+                f"Invalid value: {s}. Format must be type:id:topic. E.g. "
+                "120:54368:fixed/topic/name"
+            ) from exc
+
+    mqtt_args.add_argument(
+        "--device-topic",
+        action="append",
+        type=device_topic,
+        dest="device_topics",
+        help="Specify which topic to post device data to. On the form type:id:topic. May be repeated.",
+    )
+    antmqtt.set_defaults(func=MqttTarget.entry)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dynamic = ["readme", "version"]
 [project.optional-dependencies]
 serial = ["pyserial"]
 influx = ["influxdb-client"]
+mqtt = ["paho-mqtt"]
 test = ["pytest", "black", "pylint"]
 docs = ["sphinx>=5.2.3", "furo>=2021.3.20b30", "sphinx_mdinclude"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,6 @@ disable = [
 logging-format-style = "new"
 
 [tool.pytest.ini_options]
-addopts = "--verbose --doctest-modules --ignore=openant/subparsers/influx.py"
+addopts = "--verbose --doctest-modules --ignore=openant/subparsers/influx.py --ignore=openant/subparsers/mqtt.py"
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL"
 testpaths = "openant"


### PR DESCRIPTION
Allows sending received ANT+ packets to an MQTT server, in a similar way to how the InfluxDB subparser works. This adds an optional dependency on paho-mqtt with the selector "mqtt".

By default, data will be posted to the topic `openant/<DeviceType>/<DeviceId>`. This can be overridden with the option `--device-topic`, which lets the user directly control which topic is used for a given device. This might be needed for easier integration with external systems.

By default, data will be posted as a single JSON data string to the topic (e.g. `openant/HeartRate/54368`), since this appears to be most common method in use. Alternatively, by enabling the `--topic-per-field` option, data will be posted as individual topic below the device. E.g.: `openant/HeartRate/54368/heart_rate` will contain a single integer.
